### PR TITLE
Fix naming of the scc rolebinding for backstage

### DIFF
--- a/backstage/backstage/templates/rolebindings.yaml
+++ b/backstage/backstage/templates/rolebindings.yaml
@@ -27,7 +27,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: default-anyuid
+  name: backstage-anyuid
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Two different role bindings were using the same name and overwriting eachother.