### PR TITLE
Retrieve the accessKeyID from cert-manager-dns-credentials

### DIFF
--- a/cert-manager/cert-manager-issuers/templates/letsencrypt-issuer.yaml
+++ b/cert-manager/cert-manager-issuers/templates/letsencrypt-issuer.yaml
@@ -35,7 +35,9 @@ spec:
     - dns01:
       # Here we define a list of DNS-01 providers that can solve DNS challenges
         route53:
-          accessKeyID: dummy
+          accessKeyIDSecretRef:
+            name: cert-manager-dns-credentials
+            key: aws_access_key_id
           secretAccessKeySecretRef:
             name: cert-manager-dns-credentials
             key: aws_secret_access_key

--- a/openshift-config/openshift-config/templates/patches.yaml
+++ b/openshift-config/openshift-config/templates/patches.yaml
@@ -215,7 +215,9 @@ spec:
             solvers:
             - dns01:
                 route53:
-                  accessKeyID: {{ "{{" }} (index . 3).data.aws_access_key_id | b64dec {{ "}}" }}
+                  accessKeyIDSecretRef:
+                    name: cert-manager-dns-credentials
+                    key: aws_access_key_id
                   secretAccessKeySecretRef:
                     name: cert-manager-dns-credentials
                     key: aws_secret_access_key


### PR DESCRIPTION
cert-manager-dns-credentials is already created with both accesskey
secret and access key ID. Let's reuse it from there.
